### PR TITLE
Limit directions to EAST, SOUTHEAST, and SOUTHWEST.

### DIFF
--- a/src/Direction.java
+++ b/src/Direction.java
@@ -6,9 +6,6 @@ import traingame.Point;
 // https://www.redblobgames.com/grids/hexagons/#neighbors
 public enum Direction {
     EAST(new Point(1, 0)),
-    WEST(new Point(-1, 0)),
-    NORTHEAST(new Point(1,-1)),
-    NORTHWEST(new Point(0,-1)),
     SOUTHEAST(new Point(0,1)),
     SOUTHWEST(new Point(-1,1));
 


### PR DESCRIPTION
Effectively makes rails two-way by limiting their direction to only east, southeast or southwest.